### PR TITLE
Allow modification of task on fail and allow customization of the frontend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+REPORTER = spec
+
+test: 
+	@NODE_ENV=test ./node_modules/.bin/mocha \
+    --reporter $(REPORTER) \
+    --globals app,settings \
+
+
+test-w: 
+	@NODE_ENV=test ./node_modules/.bin/mocha \
+    --reporter $(REPORTER) \
+    --growl \
+    --watch \
+    --globals app,settings \
+	
+
+.PHONY: test test-w

--- a/README.md
+++ b/README.md
@@ -45,11 +45,37 @@ To process your messages you have to create one or multiply clients that will
 
     queue.process(function(task, done) {
         console.log(task); // -> { "foo": { "bar": true }, "data": [10, 20] }
-        done(null, true);
+        done(null);
     }, concurrency);
 
 Please note that you have to call `done` function and pass error as the first argument
-(if there are any) and result as a second argument.
+(if there are any). 
+
+The second argument is optional data that will replace the current task (if it fails) with the new data. This can be used for keep track of the number of tries, or updating the data to be worked on based on certain fail conditions. 
+
+For example: 
+    
+    var request = require("request");
+    queue.process(function(task, done){
+        request
+            .get(task.url + "/api/data.json")
+            .query({something: task.something})
+            .end(function(err, res){
+                if(err) {
+                    //Retry the task with the same data
+                    return done(err);
+                }
+
+                if(!res.results) {
+                    //Update the task's url property to try a different version of the api
+                    task.url = task.url + "/v2/";
+                    return done(err, task); 
+                }
+
+                //Otherwise everything is all good in the hood
+                return done(null);
+            });
+    });
 
 If task failed, it will be pushed back to the queue for another attempt.
 Otherwise you can set a `retry` flag to false so failed tasks will be ignored.

--- a/README.md
+++ b/README.md
@@ -117,5 +117,14 @@ Also you can setup your monitoring tools to check the queue health by using spec
 This method returns `200` if everything is fine, otherwise status would be `500`. The check fetches
 last 15 minutes of history and detects if your workers can't handle all tasks you create.
 
+Frontend uses express and exposes `app` for customization, for example adding basic authentication: 
+
+    var 
+        frontend = require("./frontend"),
+        express = require("express");
+
+    frontend.app.use(express.basicAuth("user", "pass"));
+
+    frontend.listen(3000);
 
 

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -1,17 +1,17 @@
+var worker = require("./worker");
 
-module.exports.listen = function(port, host, opts) {
+module.exports.app = worker.app;
 
-    var worker  = require('./worker'),
-        redisq  = require('../');
+module.exports.listen = function(port, done, opts) {
 
-    if (typeof opts == "object")
-        redisq.options(opts);
+    var redisq  = require('../');
+
+    if (typeof opts == "object") redisq.options(opts);
 
     port = port || 3000;
-    host = host || "localhost";
+    done = done || function(){};
 
-    console.log('Redisq frontend has been started on %s:%s, pid: %s',
-            host, port, process.pid);
+    worker.configure();
+    worker.app.listen(port, done);
 
-    worker.listen(port, host);
 };

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -2,16 +2,19 @@ var worker = require("./worker");
 
 module.exports.app = worker.app;
 
-module.exports.listen = function(port, done, opts) {
+module.exports.listen = function(port, host, opts) {
 
     var redisq  = require('../');
 
     if (typeof opts == "object") redisq.options(opts);
 
     port = port || 3000;
-    done = done || function(){};
+    host = host || "localhost";
 
     worker.configure();
-    worker.app.listen(port, done);
+    worker.app.listen(port, host, function(){
+        console.log('Redisq frontend has been started on %s:%s, pid: %s',
+            host, port, process.pid);
+    });
 
 };

--- a/frontend/worker.js
+++ b/frontend/worker.js
@@ -2,28 +2,35 @@
 var express = require('express'),
     app = express();
 
-app.configure(function() {
-    app.set('views', __dirname + '/views');
-    app.set('view engine', 'jade');
-    app.disable('view cache');
-    app.use(express.static(__dirname + '/public'));
-});
+module.exports.app = app;
 
-// helpers
-app.locals.addCommas = require(__dirname + '/views/helpers/add_commas');
-app.locals.pretty = true;
+module.exports.configure = function(){
+    //app.use(express.basicAuth("foo", "bar"));
+    app.configure(function() {
+        app.set('views', __dirname + '/views');
+        app.set('view engine', 'jade');
+        app.disable('view cache');
+        app.use(express.static(__dirname + '/public'));
+    });
 
-app.get("/favicon.ico", function(req, res) {
-    res.end("");
-});
-app.get("/", require(__dirname + '/controllers/index').index);
-app.get("/queues/:name", require(__dirname + '/controllers/queues').show);
-app.get("/queues/:name/history", require(__dirname + '/controllers/queues').history);
-app.post("/queues/:name/purge", require(__dirname + '/controllers/queues').purge);
-app.post("/queues/:name/counters-reset", require(__dirname + '/controllers/queues').countersReset);
-app.get("/queues/:name/counters", require(__dirname + '/controllers/queues').countersGet);
-app.post("/queues/:name/history-reset", require(__dirname + '/controllers/queues').historyReset);
-app.get("/status", require(__dirname + '/controllers/status'));
+    // helpers
+    app.locals.addCommas = require(__dirname + '/views/helpers/add_commas');
+    app.locals.pretty = true;
+
+    app.get("/favicon.ico", function(req, res) {
+        res.end("");
+    });
+    app.get("/", require(__dirname + '/controllers/index').index);
+    app.get("/queues/:name", require(__dirname + '/controllers/queues').show);
+    app.get("/queues/:name/history", require(__dirname + '/controllers/queues').history);
+    app.post("/queues/:name/purge", require(__dirname + '/controllers/queues').purge);
+    app.post("/queues/:name/counters-reset", require(__dirname + '/controllers/queues').countersReset);
+    app.get("/queues/:name/counters", require(__dirname + '/controllers/queues').countersGet);
+    app.post("/queues/:name/history-reset", require(__dirname + '/controllers/queues').historyReset);
+    app.get("/status", require(__dirname + '/controllers/status'));
+}
 
 
-module.exports = app;
+
+
+

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -89,7 +89,10 @@ module.exports = (function(name, opts) {
                     _stats.cnt.timeFinished  += (finished - task.getCreatedAt());
 
                     // refactor this mess?
-                    if (err) _stats.cnt.failed++;
+                    if (err) {
+                        if(res) task = new Task(res);
+                        _stats.cnt.failed++;
+                    }
                     else     _stats.cnt.processed++;
 
                     // pushing a failed task to the head of the queue

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -90,7 +90,8 @@ module.exports = (function(name, opts) {
 
                     // refactor this mess?
                     if (err) {
-                        if(res) task = new Task(res);
+
+                        if(res && typeof res == "object") task = new Task(res);
                         _stats.cnt.failed++;
                     }
                     else     _stats.cnt.processed++;

--- a/test/queue.js
+++ b/test/queue.js
@@ -163,7 +163,7 @@ describe("/lib/queue", function() {
             })
         });
 
-        it("should not lost task if it was failed first time", function(done) {
+        it("should not lose a task if it failed the first time", function(done) {
             var first = true;
             var processed = 0;
             var worker = function(task, cb) {
@@ -227,6 +227,35 @@ describe("/lib/queue", function() {
                 q.push(t, function() {});
 
             q.process(worker, 4);
+        });
+
+        it("should update a task on failure", function(done){
+            
+            var work = 0;
+            var worker = function(task, cb) {
+                if(work > 0) {
+                    assert.equal(task.err, false);
+                    assert.equal(task.yay, 1);
+                    return done();
+                } else {
+                    work++;
+                    assert.equal(task.err, true);
+                    assert.equal(task.yay, 0);
+                }
+               
+                if(task.err) {
+                    task.err = false;
+                    task.yay = 1;
+                    cb(true, task);
+                } else {
+                    cb(null);
+                }
+            };
+
+            q.push({ err: true, yay: 0 }, function(err,res){
+                q.process(worker, 1);    
+            });
+            
         });
 
     });


### PR DESCRIPTION
When tasks were failing the `res` object on the callback wasn't being used, so I used it to update the task with new data. So a user could use it to keep track of the number of times a task failed, or try a modification of the task based on different fail criteria. 

Now the frontend exposes `app` for customization, for example adding basic authentication: 

```
var 
    frontend = require("./frontend"),
    express = require("express");

frontend.app.use(express.basicAuth("user", "pass"));

frontend.listen(3000);
```

P.S. great module, super simple compared to a lot of the other node redis queues available 
