### PR TITLE
Pause/resume the queue processing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,22 @@ Otherwise you can set a `retry` flag to false so failed tasks will be ignored.
     var queue = redisq.queue("myqueue");
     queue.retry = false;
 
+Optionally, you can pause the queue in the event your downstream prerequisites have
+failed.  Within your processing function, call `queue.pause()`.  Once the queue
+is ready to proceed, call `queue.resume()`.
+
+    var queue = redisq.queue('dummy');
+    (function headsOrTails() {
+      if (Math.random() > .5) { queue.resume(); } else { console.log("Not this time. :("); }
+      setTimeout(headsOrTails, 2000);
+    })();
+
+    queue.process(function(task, done) {
+      console.log(task); // -> { "foo": { "bar": true }, "data": [10, 20] }
+      queue.pause();
+      done({ message: 'You broke it!' });
+    });
+
 ## Frontend
 
 Module has a useful frontend that you can use for monitoring of the queue status.

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -15,9 +15,18 @@ module.exports = (function(name, opts) {
     this.workersActive  = 0;
     this.concurrency    = 1;
     this.retry          = true;
+    this.active         = true;
 
     function _constructor () {
         self.register();
+    };
+
+    this.pause = function() {
+      self.active = false;
+    };
+
+    this.resume = function() {
+      self.active = true;
     };
 
     this.push = function(task, fn) {
@@ -73,6 +82,10 @@ module.exports = (function(name, opts) {
     };
 
     function _spawn() {
+        if (!self.active) {
+            setTimeout(_spawn, 250);
+            return self.workersActive--;
+        }
         _redis.lpop("redisq:" + self.name + ":queue", function(err, tdata) {
             if (err) throw new Error(err);
 

--- a/test/queue.js
+++ b/test/queue.js
@@ -258,6 +258,53 @@ describe("/lib/queue", function() {
             
         });
 
+        it("should create more items", function(done) {
+            var tasksPushed = 0;
+            var tasks = [];
+            for (var i = 0; i < tasksn; i++)
+                q.push('dummy', function(err, res) {
+                    assert.equal(err, null);
+                    assert.equal(res, true);
+                    tasksPushed++;
+                });
+            setTimeout(function() {
+                assert.equal(tasksn, tasksPushed);
+                done();
+            }, 10);
+        });
+
+        it("should process half the items and pause", function(done) {
+            var finished = 0;
+            function worker(task, cb) {
+                finished++;
+                if (finished === 13) {
+                    q.pause();
+                    done();
+                    setTimeout(function() {
+                        assert.notEqual(finished, 25);
+                    }, 20);
+                } else if (finished < 13) {
+                    cb();
+                } else {
+                    cb(true);
+                }
+            }
+
+            q.process(worker, 1);
+        });
+
+        it("should return false if the queue is paused", function(done) {
+            assert.equal(q.active, false);
+            done();
+        });
+
+        it("should return len 12 after half processing", function(done) {
+            q.len(function(err, len) {
+                assert.equal(len, 12);
+                done();
+            })
+        });
+
     });
 
 });


### PR DESCRIPTION
In the event of an error downstream, we want to be able to pause
the processing of further messages without causing unnecessary
overhead.
