### PR TITLE
analyze only records for last 30 minutes in status check

### DIFF
--- a/frontend/controllers/status.js
+++ b/frontend/controllers/status.js
@@ -4,35 +4,40 @@ var redisq = require('../../');
 module.exports = function(req, res) {
 	redisq.getStats(function(err, stats) {
 
-        var measureLastMins = 15,
+        var measureLastRecords = 15,
             rateThreshold = 1.0, // overhead 2x times
             problems = {},
-            queued = 0;
+            queued = 0,
+            now = (new Date()).getTime(),
+            halfAnHour = 1000 * 60 * 30;
 
 		for (var name in stats) {
             queued += stats[name].counters.queued;
             var history = stats[name].history;
 
             // skip recently started queues
-            if (history.length < measureLastMins)
+            if (history.length < measureLastRecords)
                 continue;
 
             // get last 15 records
-            var last15 = history.splice(history.length - measureLastMins);
+            var last15 = history.splice(history.length - measureLastRecords);
 
             var created = 0,
                 processed = 0;
 
             for (var i = last15.length - 1; i >= 0; i--) {
+                // skip records older than 30 minutes
+                if (now - last15[i].createdAt > halfAnHour)
+                    continue;
                 created   += last15[i].created;
                 processed += last15[i].processed;
-            };
+            }
 
             var rate = Math.round(Math.abs(1 - created / processed) * 1000) / 1000;
 
             if (rate >= rateThreshold)
                 problems[name] = {
-                    "measured":  60 * measureLastMins,
+                    "measured":  60 * measureLastRecords,
                     "created":   created,
                     "processed": processed,
                     "diffrate":  rate


### PR DESCRIPTION
History check in frontend was made with the intention to check only records in last 15 minutes, however it check last 15 records in history. So if there were no tasks in my query since yesterday then this check will report about problem in last 15 records even one day after it.
